### PR TITLE
headers relative path javascript

### DIFF
--- a/debian/patches/fusiondirectory-headers.patch
+++ b/debian/patches/fusiondirectory-headers.patch
@@ -10,7 +10,7 @@ Index: pkg/core/ihtml/themes/default/headers.tpl
    <link rel="shortcut icon" href="favicon.ico"/>
  
 -  <script src="include/prototype.js" type="text/javascript"></script>
-+  <script src="/javascript/prototype/prototype.js" type="text/javascript"></script>
++  <script src="javascript/prototype/prototype.js" type="text/javascript"></script>
    <script src="include/fusiondirectory.js" type="text/javascript"></script>
  {if $usePrototype == 'true'}
 -  <script src="include/scriptaculous.js" type="text/javascript"></script>

--- a/debian/patches/fusiondirectory-headers.patch
+++ b/debian/patches/fusiondirectory-headers.patch
@@ -18,11 +18,11 @@ Index: pkg/core/ihtml/themes/default/headers.tpl
 -  <script src="include/effects.js" type="text/javascript"></script>
 -  <script src="include/dragdrop.js" type="text/javascript"></script>
 -  <script src="include/controls.js" type="text/javascript"></script>
-+  <script src="/javascript/scriptaculous/scriptaculous.js" type="text/javascript"></script>
-+  <script src="/javascript/scriptaculous/builder.js" type="text/javascript"></script>
-+  <script src="/javascript/scriptaculous/effects.js" type="text/javascript"></script>
-+  <script src="/javascript/scriptaculous/dragdrop.js" type="text/javascript"></script>
-+  <script src="/javascript/scriptaculous/controls.js" type="text/javascript"></script>
++  <script src="javascript/scriptaculous/scriptaculous.js" type="text/javascript"></script>
++  <script src="javascript/scriptaculous/builder.js" type="text/javascript"></script>
++  <script src="javascript/scriptaculous/effects.js" type="text/javascript"></script>
++  <script src="javascript/scriptaculous/dragdrop.js" type="text/javascript"></script>
++  <script src="javascript/scriptaculous/controls.js" type="text/javascript"></script>
    <script src="include/pulldown.js" type="text/javascript"></script>
    <script src="include/datepicker.js" type="text/javascript"></script>
  {/if}


### PR DESCRIPTION
Patch for javascript relative path without this in Debian javascripts not downloaded if url http(s)://server/fusiondirectory/